### PR TITLE
Fix count issue which logs error in smf logs

### DIFF
--- a/AwardsSubs.php
+++ b/AwardsSubs.php
@@ -40,7 +40,7 @@ function AwardsLoadAward($id = -1)
 	$row = $smcFunc['db_fetch_assoc']($request);
 
 	// Check if that award actually exists
-	if (count($row['id_award']) != 1)
+	if (empty($row['id_award']))
 		fatal_lang_error('awards_error_no_award');
 
 	$award = array(


### PR DESCRIPTION
The original code has been generating problem "Your variable does not implement Countable". The value at $row['id_award'] is a string.

Closes #52 